### PR TITLE
feat: Add action/payout fields to pipeline, train/val split, refactor sharding

### DIFF
--- a/alpharat/data/loader.py
+++ b/alpharat/data/loader.py
@@ -57,6 +57,8 @@ def load_game_data(path: Path | str) -> GameData:
             prior_p2=data["prior_p2"][i].copy(),
             policy_p1=data["policy_p1"][i].copy(),
             policy_p2=data["policy_p2"][i].copy(),
+            action_p1=int(data["action_p1"][i]),
+            action_p2=int(data["action_p2"][i]),
         )
         positions.append(position)
 

--- a/alpharat/data/recorder.py
+++ b/alpharat/data/recorder.py
@@ -117,6 +117,8 @@ class GameRecorder:
         prior_p1: np.ndarray,
         prior_p2: np.ndarray,
         visit_counts: np.ndarray,
+        action_p1: int,
+        action_p2: int,
     ) -> None:
         """Record data for the current position.
 
@@ -129,6 +131,8 @@ class GameRecorder:
             prior_p1: Neural network's policy prior for player 1.
             prior_p2: Neural network's policy prior for player 2.
             visit_counts: MCTS visit counts for action pairs.
+            action_p1: Action taken by player 1 (0-4).
+            action_p2: Action taken by player 2 (0-4).
 
         Raises:
             RuntimeError: If not inside context manager.
@@ -151,6 +155,8 @@ class GameRecorder:
             prior_p2=prior_p2.copy(),
             policy_p1=search_result.policy_p1.copy(),
             policy_p2=search_result.policy_p2.copy(),
+            action_p1=action_p1,
+            action_p2=action_p2,
         )
         self.data.positions.append(position)
 
@@ -216,6 +222,10 @@ class GameRecorder:
                 raise ValueError(f"Position {i}: invalid policy_p1 shape {pos.policy_p1.shape}")
             if pos.policy_p2.shape != (5,):
                 raise ValueError(f"Position {i}: invalid policy_p2 shape {pos.policy_p2.shape}")
+            if not (0 <= pos.action_p1 <= 4):
+                raise ValueError(f"Position {i}: invalid action_p1 {pos.action_p1}")
+            if not (0 <= pos.action_p2 <= 4):
+                raise ValueError(f"Position {i}: invalid action_p2 {pos.action_p2}")
 
     def _build_arrays(self) -> dict[str, np.ndarray]:
         """Convert accumulated data to numpy arrays for saving.
@@ -242,6 +252,8 @@ class GameRecorder:
         prior_p2 = np.zeros((n, 5), dtype=np.float32)
         policy_p1 = np.zeros((n, 5), dtype=np.float32)
         policy_p2 = np.zeros((n, 5), dtype=np.float32)
+        action_p1 = np.zeros(n, dtype=np.int8)
+        action_p2 = np.zeros(n, dtype=np.int8)
 
         for i, pos in enumerate(self.data.positions):
             p1_pos[i] = pos.p1_pos
@@ -258,6 +270,8 @@ class GameRecorder:
             prior_p2[i] = pos.prior_p2.astype(np.float32)
             policy_p1[i] = pos.policy_p1.astype(np.float32)
             policy_p2[i] = pos.policy_p2.astype(np.float32)
+            action_p1[i] = np.int8(pos.action_p1)
+            action_p2[i] = np.int8(pos.action_p2)
 
         return {
             # Game-level
@@ -283,6 +297,8 @@ class GameRecorder:
             "prior_p2": prior_p2,
             "policy_p1": policy_p1,
             "policy_p2": policy_p2,
+            "action_p1": action_p1,
+            "action_p2": action_p2,
         }
 
     def _cheese_to_mask(self, cheese_positions: list[tuple[int, int]]) -> np.ndarray:

--- a/alpharat/data/sampling.py
+++ b/alpharat/data/sampling.py
@@ -192,6 +192,10 @@ def play_and_record_game(
             positions += 1
             total_simulations += config.mcts.simulations
 
+            # Sample actions from Nash equilibrium policies
+            a1 = select_action_from_strategy(result.policy_p1)
+            a2 = select_action_from_strategy(result.policy_p2)
+
             # Record position before making move
             recorder.record_position(
                 game=game,
@@ -199,11 +203,9 @@ def play_and_record_game(
                 prior_p1=tree.root.prior_policy_p1,
                 prior_p2=tree.root.prior_policy_p2,
                 visit_counts=tree.root.action_visits,
+                action_p1=a1,
+                action_p2=a2,
             )
-
-            # Sample actions from Nash equilibrium policies
-            a1 = select_action_from_strategy(result.policy_p1)
-            a2 = select_action_from_strategy(result.policy_p2)
 
             game.make_move(a1, a2)
 

--- a/alpharat/data/sharding.py
+++ b/alpharat/data/sharding.py
@@ -62,6 +62,9 @@ def prepare_training_set(
         - policy_p1: float32 (N, 5)
         - policy_p2: float32 (N, 5)
         - value: float32 (N,)
+        - payout_matrix: float32 (N, 5, 5)
+        - action_p1: int8 (N,)
+        - action_p2: int8 (N,)
 
     Args:
         batch_dirs: List of batch directories to process.
@@ -80,9 +83,17 @@ def prepare_training_set(
         raise ValueError("batch_dirs cannot be empty")
 
     # Load all positions
-    all_obs, all_policy_p1, all_policy_p2, all_values, width, height = _load_all_positions(
-        batch_dirs, builder
-    )
+    (
+        all_obs,
+        all_policy_p1,
+        all_policy_p2,
+        all_values,
+        all_payout_matrices,
+        all_action_p1,
+        all_action_p2,
+        width,
+        height,
+    ) = _load_all_positions(batch_dirs, builder)
 
     total_positions = len(all_values)
     if total_positions == 0:
@@ -96,6 +107,9 @@ def prepare_training_set(
     all_policy_p1 = all_policy_p1[indices]
     all_policy_p2 = all_policy_p2[indices]
     all_values = all_values[indices]
+    all_payout_matrices = all_payout_matrices[indices]
+    all_action_p1 = all_action_p1[indices]
+    all_action_p2 = all_action_p2[indices]
 
     # Create training set directory
     training_set_id = str(uuid.uuid4())
@@ -109,6 +123,9 @@ def prepare_training_set(
         all_policy_p1,
         all_policy_p2,
         all_values,
+        all_payout_matrices,
+        all_action_p1,
+        all_action_p2,
         positions_per_shard,
     )
 
@@ -129,6 +146,184 @@ def prepare_training_set(
     return training_set_dir
 
 
+def prepare_training_set_with_split(
+    batch_dirs: list[Path],
+    output_dir: Path,
+    builder: ObservationBuilder,
+    *,
+    val_ratio: float = 0.1,
+    positions_per_shard: int = 10000,
+    seed: int | None = None,
+) -> Path:
+    """Prepare training set with game-level train/val split.
+
+    Splits games (not positions) into train and validation sets to prevent
+    data leakage between positions in the same game.
+
+    Directory structure created:
+        {output_dir}/{training_set_id}/
+            train/
+                manifest.json
+                shard_0000.npz
+                ...
+            val/
+                manifest.json
+                shard_0000.npz
+                ...
+
+    Args:
+        batch_dirs: List of batch directories to process.
+        output_dir: Parent directory for training sets.
+        builder: ObservationBuilder to use for encoding.
+        val_ratio: Fraction of games to use for validation (0.0 to 1.0).
+        positions_per_shard: Maximum positions per shard file.
+        seed: Random seed for shuffling. If None, uses random seed.
+
+    Returns:
+        Path to created training set directory (parent containing train/ and val/).
+
+    Raises:
+        ValueError: If batch_dirs is empty, val_ratio invalid, or dimensions mismatch.
+    """
+    if not batch_dirs:
+        raise ValueError("batch_dirs cannot be empty")
+    if not 0.0 <= val_ratio < 1.0:
+        raise ValueError(f"val_ratio must be in [0.0, 1.0), got {val_ratio}")
+
+    # Collect all game files
+    game_files: list[Path] = []
+    for batch_dir in batch_dirs:
+        games_dir = batch_dir / "games"
+        if games_dir.exists():
+            game_files.extend(games_dir.glob("*.npz"))
+
+    if not game_files:
+        raise ValueError("No game files found in batch directories")
+
+    # Shuffle and split at game level
+    rng = np.random.default_rng(seed)
+    indices = rng.permutation(len(game_files))
+    shuffled_files = [game_files[i] for i in indices]
+
+    n_val = int(len(shuffled_files) * val_ratio)
+    val_files = shuffled_files[:n_val]
+    train_files = shuffled_files[n_val:]
+
+    if not train_files:
+        raise ValueError("No games left for training after split")
+
+    # Create parent directory
+    training_set_id = str(uuid.uuid4())
+    training_set_dir = output_dir / training_set_id
+    training_set_dir.mkdir(parents=True, exist_ok=False)
+
+    # Process train split
+    train_dir = training_set_dir / "train"
+    train_dir.mkdir()
+    _process_game_files_to_shards(
+        game_files=train_files,
+        output_dir=train_dir,
+        builder=builder,
+        positions_per_shard=positions_per_shard,
+        seed=seed,
+        training_set_id=f"{training_set_id}_train",
+        source_batches=[d.name for d in batch_dirs],
+    )
+
+    # Process val split (if any validation games)
+    if val_files:
+        val_dir = training_set_dir / "val"
+        val_dir.mkdir()
+        # Use different seed for val shuffle
+        val_seed = seed + 1 if seed is not None else None
+        _process_game_files_to_shards(
+            game_files=val_files,
+            output_dir=val_dir,
+            builder=builder,
+            positions_per_shard=positions_per_shard,
+            seed=val_seed,
+            training_set_id=f"{training_set_id}_val",
+            source_batches=[d.name for d in batch_dirs],
+        )
+
+    return training_set_dir
+
+
+def _process_game_files_to_shards(
+    game_files: list[Path],
+    output_dir: Path,
+    builder: ObservationBuilder,
+    positions_per_shard: int,
+    seed: int | None,
+    training_set_id: str,
+    source_batches: list[str],
+) -> None:
+    """Process game files into shards for a single split.
+
+    Args:
+        game_files: List of game npz files to process.
+        output_dir: Directory to write shards to.
+        builder: ObservationBuilder to use.
+        positions_per_shard: Maximum positions per shard.
+        seed: Random seed for shuffling positions.
+        training_set_id: ID for the manifest.
+        source_batches: Batch names for the manifest.
+    """
+    # Load and process all positions
+    (
+        obs_array,
+        policy_p1_array,
+        policy_p2_array,
+        values_array,
+        payout_array,
+        action_p1_array,
+        action_p2_array,
+        width,
+        height,
+    ) = _load_positions_from_files(game_files, builder)
+
+    total_positions = len(values_array)
+
+    # Shuffle positions within this split
+    rng = np.random.default_rng(seed)
+    indices = rng.permutation(total_positions)
+
+    obs_array = obs_array[indices]
+    policy_p1_array = policy_p1_array[indices]
+    policy_p2_array = policy_p2_array[indices]
+    values_array = values_array[indices]
+    payout_array = payout_array[indices]
+    action_p1_array = action_p1_array[indices]
+    action_p2_array = action_p2_array[indices]
+
+    # Write shards
+    shard_count = _write_shards(
+        output_dir,
+        obs_array,
+        policy_p1_array,
+        policy_p2_array,
+        values_array,
+        payout_array,
+        action_p1_array,
+        action_p2_array,
+        positions_per_shard,
+    )
+
+    # Write manifest
+    manifest = TrainingSetManifest(
+        training_set_id=training_set_id,
+        created_at=datetime.now(UTC),
+        builder_version=builder.version,
+        source_batches=source_batches,
+        total_positions=total_positions,
+        shard_count=shard_count,
+        positions_per_shard=positions_per_shard,
+        width=width,
+        height=height,
+    )
+    _save_manifest(output_dir, manifest)
+
+
 def load_training_set_manifest(training_set_dir: Path) -> TrainingSetManifest:
     """Load manifest from training set directory.
 
@@ -146,14 +341,16 @@ def load_training_set_manifest(training_set_dir: Path) -> TrainingSetManifest:
     return TrainingSetManifest.model_validate(data)
 
 
-def _load_all_positions(
-    batch_dirs: list[Path],
+def _load_positions_from_files(
+    game_files: list[Path],
     builder: ObservationBuilder,
-) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, int, int]:
-    """Load all positions from batches and build observations/targets.
+) -> tuple[
+    np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, int, int
+]:
+    """Load and process positions from game files into stacked arrays.
 
     Args:
-        batch_dirs: List of batch directories.
+        game_files: List of game npz files to process.
         builder: ObservationBuilder to use.
 
     Returns:
@@ -162,60 +359,98 @@ def _load_all_positions(
             - policy_p1: float32 (N, 5)
             - policy_p2: float32 (N, 5)
             - values: float32 (N,)
+            - payout_matrices: float32 (N, 5, 5)
+            - action_p1: int8 (N,)
+            - action_p2: int8 (N,)
             - width: int
             - height: int
 
     Raises:
-        ValueError: If batches have different dimensions.
+        ValueError: If game files have different dimensions or no positions found.
     """
     all_observations: list[np.ndarray] = []
     all_policy_p1: list[np.ndarray] = []
     all_policy_p2: list[np.ndarray] = []
     all_values: list[float] = []
+    all_payout_matrices: list[np.ndarray] = []
+    all_action_p1: list[int] = []
+    all_action_p2: list[int] = []
 
     width: int | None = None
     height: int | None = None
 
-    for batch_dir in batch_dirs:
-        games_dir = batch_dir / "games"
-        if not games_dir.exists():
-            continue
+    for game_file in game_files:
+        game_data = load_game_data(game_file)
 
-        for game_file in games_dir.glob("*.npz"):
-            game_data = load_game_data(game_file)
+        # Validate dimensions
+        if width is None:
+            width = game_data.width
+            height = game_data.height
+        elif game_data.width != width or game_data.height != height:
+            raise ValueError(
+                f"Dimension mismatch: expected ({width}, {height}), "
+                f"got ({game_data.width}, {game_data.height}) in {game_file}"
+            )
 
-            # Validate dimensions
-            if width is None:
-                width = game_data.width
-                height = game_data.height
-            elif game_data.width != width or game_data.height != height:
-                raise ValueError(
-                    f"Dimension mismatch: expected ({width}, {height}), "
-                    f"got ({game_data.width}, {game_data.height}) in {game_file}"
-                )
+        # Process each position
+        for position in game_data.positions:
+            obs_input = from_game_arrays(game_data, position)
+            obs = builder.build(obs_input)
+            targets = build_targets(game_data, position)
 
-            # Process each position
-            for position in game_data.positions:
-                obs_input = from_game_arrays(game_data, position)
-                obs = builder.build(obs_input)
-                targets = build_targets(game_data, position)
-
-                all_observations.append(obs)
-                all_policy_p1.append(targets.policy_p1)
-                all_policy_p2.append(targets.policy_p2)
-                all_values.append(targets.value)
+            all_observations.append(obs)
+            all_policy_p1.append(targets.policy_p1)
+            all_policy_p2.append(targets.policy_p2)
+            all_values.append(targets.value)
+            all_payout_matrices.append(targets.payout_matrix)
+            all_action_p1.append(targets.action_p1)
+            all_action_p2.append(targets.action_p2)
 
     if width is None or height is None:
-        raise ValueError("No games found in batch directories")
+        raise ValueError("No positions found in game files")
 
     return (
         np.stack(all_observations),
         np.stack(all_policy_p1),
         np.stack(all_policy_p2),
         np.array(all_values, dtype=np.float32),
+        np.stack(all_payout_matrices),
+        np.array(all_action_p1, dtype=np.int8),
+        np.array(all_action_p2, dtype=np.int8),
         width,
         height,
     )
+
+
+def _load_all_positions(
+    batch_dirs: list[Path],
+    builder: ObservationBuilder,
+) -> tuple[
+    np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, int, int
+]:
+    """Load all positions from batches and build observations/targets.
+
+    Args:
+        batch_dirs: List of batch directories.
+        builder: ObservationBuilder to use.
+
+    Returns:
+        Tuple of stacked arrays and dimensions. See _load_positions_from_files.
+
+    Raises:
+        ValueError: If batches have different dimensions or no games found.
+    """
+    # Collect all game files from batch directories
+    game_files: list[Path] = []
+    for batch_dir in batch_dirs:
+        games_dir = batch_dir / "games"
+        if games_dir.exists():
+            game_files.extend(games_dir.glob("*.npz"))
+
+    if not game_files:
+        raise ValueError("No games found in batch directories")
+
+    return _load_positions_from_files(game_files, builder)
 
 
 def _write_shards(
@@ -224,6 +459,9 @@ def _write_shards(
     policy_p1: np.ndarray,
     policy_p2: np.ndarray,
     values: np.ndarray,
+    payout_matrices: np.ndarray,
+    action_p1: np.ndarray,
+    action_p2: np.ndarray,
     positions_per_shard: int,
 ) -> int:
     """Write shards to training set directory.
@@ -234,6 +472,9 @@ def _write_shards(
         policy_p1: All P1 policies, shape (N, 5).
         policy_p2: All P2 policies, shape (N, 5).
         values: All values, shape (N,).
+        payout_matrices: All payout matrices, shape (N, 5, 5).
+        action_p1: All P1 actions, shape (N,).
+        action_p2: All P2 actions, shape (N,).
         positions_per_shard: Maximum positions per shard.
 
     Returns:
@@ -252,6 +493,9 @@ def _write_shards(
             policy_p1=policy_p1[start_idx:end_idx],
             policy_p2=policy_p2[start_idx:end_idx],
             value=values[start_idx:end_idx],
+            payout_matrix=payout_matrices[start_idx:end_idx],
+            action_p1=action_p1[start_idx:end_idx],
+            action_p2=action_p2[start_idx:end_idx],
         )
         shard_count += 1
 

--- a/alpharat/data/types.py
+++ b/alpharat/data/types.py
@@ -31,6 +31,8 @@ class PositionData:
     prior_p2: np.ndarray  # (5,)
     policy_p1: np.ndarray  # (5,)
     policy_p2: np.ndarray  # (5,)
+    action_p1: int  # action taken by player 1 (0-4)
+    action_p2: int  # action taken by player 2 (0-4)
 
 
 @dataclass

--- a/alpharat/nn/builders/flat.py
+++ b/alpharat/nn/builders/flat.py
@@ -182,6 +182,9 @@ class FlatDataset:
         policy_p1_list: list[np.ndarray] = []
         policy_p2_list: list[np.ndarray] = []
         value_list: list[np.ndarray] = []
+        payout_matrix_list: list[np.ndarray] = []
+        action_p1_list: list[np.ndarray] = []
+        action_p2_list: list[np.ndarray] = []
 
         for i in range(self._manifest.shard_count):
             shard_path = training_set_dir / f"shard_{i:04d}.npz"
@@ -190,11 +193,17 @@ class FlatDataset:
                 policy_p1_list.append(data["policy_p1"])
                 policy_p2_list.append(data["policy_p2"])
                 value_list.append(data["value"])
+                payout_matrix_list.append(data["payout_matrix"])
+                action_p1_list.append(data["action_p1"])
+                action_p2_list.append(data["action_p2"])
 
         self._observations = np.concatenate(observations_list)
         self._policy_p1 = np.concatenate(policy_p1_list)
         self._policy_p2 = np.concatenate(policy_p2_list)
         self._value = np.concatenate(value_list)
+        self._payout_matrix = np.concatenate(payout_matrix_list)
+        self._action_p1 = np.concatenate(action_p1_list)
+        self._action_p2 = np.concatenate(action_p2_list)
 
         # Build observation builder for shape info
         self._builder = FlatObservationBuilder(
@@ -216,13 +225,19 @@ class FlatDataset:
                 - "observation": float32 (obs_dim,)
                 - "policy_p1": float32 (5,)
                 - "policy_p2": float32 (5,)
-                - "value": float32 scalar array
+                - "value": float32 (1,)
+                - "payout_matrix": float32 (5, 5)
+                - "action_p1": int8 (1,)
+                - "action_p2": int8 (1,)
         """
         return {
             "observation": self._observations[idx],
             "policy_p1": self._policy_p1[idx],
             "policy_p2": self._policy_p2[idx],
             "value": self._value[idx : idx + 1],  # Keep as 1D for consistency
+            "payout_matrix": self._payout_matrix[idx],
+            "action_p1": self._action_p1[idx : idx + 1],
+            "action_p2": self._action_p2[idx : idx + 1],
         }
 
     @property

--- a/alpharat/nn/streaming.py
+++ b/alpharat/nn/streaming.py
@@ -98,6 +98,9 @@ class StreamingDataset(IterableDataset[dict[str, torch.Tensor]]):
                         "policy_p1": torch.from_numpy(shard_data["policy_p1"][j]),
                         "policy_p2": torch.from_numpy(shard_data["policy_p2"][j]),
                         "value": torch.from_numpy(shard_data["value"][j : j + 1]),
+                        "payout_matrix": torch.from_numpy(shard_data["payout_matrix"][j]),
+                        "action_p1": torch.from_numpy(shard_data["action_p1"][j : j + 1]),
+                        "action_p2": torch.from_numpy(shard_data["action_p2"][j : j + 1]),
                     }
 
     def __len__(self) -> int:
@@ -117,7 +120,7 @@ def _load_shard(path: Path) -> dict[str, np.ndarray]:
         path: Path to shard npz file.
 
     Returns:
-        Dict with observations, policy_p1, policy_p2, value arrays.
+        Dict with observations, policy_p1, policy_p2, value, payout_matrix, action arrays.
     """
     with np.load(path) as data:
         return {
@@ -125,4 +128,7 @@ def _load_shard(path: Path) -> dict[str, np.ndarray]:
             "policy_p1": np.array(data["policy_p1"]),
             "policy_p2": np.array(data["policy_p2"]),
             "value": np.array(data["value"]),
+            "payout_matrix": np.array(data["payout_matrix"]),
+            "action_p1": np.array(data["action_p1"]),
+            "action_p2": np.array(data["action_p2"]),
         }

--- a/alpharat/nn/targets.py
+++ b/alpharat/nn/targets.py
@@ -31,7 +31,7 @@ def build_targets(game: GameData, position: PositionData) -> TargetBundle:
         position: Position-level data containing Nash policies and current scores.
 
     Returns:
-        TargetBundle with policy and value targets.
+        TargetBundle with policy, value, payout_matrix, and action targets.
     """
     final_diff = game.final_p1_score - game.final_p2_score
     current_diff = position.p1_score - position.p2_score
@@ -41,4 +41,7 @@ def build_targets(game: GameData, position: PositionData) -> TargetBundle:
         policy_p1=position.policy_p1.astype(np.float32),
         policy_p2=position.policy_p2.astype(np.float32),
         value=remaining_diff,
+        payout_matrix=position.payout_matrix.astype(np.float32),
+        action_p1=position.action_p1,
+        action_p2=position.action_p2,
     )

--- a/alpharat/nn/types.py
+++ b/alpharat/nn/types.py
@@ -54,8 +54,14 @@ class TargetBundle:
         value: Remaining score differential from this position to game end.
             Computed as (final_diff - current_diff). Positive means P1
             will gain more cheese than P2 from this position onwards.
+        payout_matrix: MCTS refined payout matrix, shape (5, 5).
+        action_p1: Action taken by player 1 (0-4).
+        action_p2: Action taken by player 2 (0-4).
     """
 
     policy_p1: np.ndarray  # float32 (5,)
     policy_p2: np.ndarray  # float32 (5,)
     value: float
+    payout_matrix: np.ndarray  # float32 (5, 5)
+    action_p1: int
+    action_p2: int

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dev = [
 ]
 train = [
     "torch>=2.0",
+    "tensorboard>=2.15",
 ]
 
 [build-system]
@@ -59,7 +60,9 @@ select = [
     "SIM",    # flake8-simplify
     "TCH",    # flake8-type-checking
 ]
-ignore = []
+ignore = [
+    "N812",   # Allow `import as F` for torch.nn.functional (PyTorch convention)
+]
 
 [tool.ruff.format]
 quote-style = "double"

--- a/tests/data/test_recorder.py
+++ b/tests/data/test_recorder.py
@@ -236,6 +236,8 @@ class TestGameRecorder:
                     prior_p1=np.ones(5) / 5,
                     prior_p2=np.ones(5) / 5,
                     visit_counts=np.zeros((5, 5), dtype=np.int32),
+                    action_p1=0,
+                    action_p2=0,
                 )
 
     def test_record_position_accumulates(self) -> None:
@@ -253,6 +255,8 @@ class TestGameRecorder:
                 prior_p1=np.ones(5) / 5,
                 prior_p2=np.ones(5) / 5,
                 visit_counts=np.zeros((5, 5), dtype=np.int32),
+                action_p1=0,
+                action_p2=0,
             )
 
             assert recorder.data is not None
@@ -266,6 +270,8 @@ class TestGameRecorder:
                 prior_p1=np.ones(5) / 5,
                 prior_p2=np.ones(5) / 5,
                 visit_counts=np.zeros((5, 5), dtype=np.int32),
+                action_p1=0,
+                action_p2=0,
             )
 
             assert len(recorder.data.positions) == 2
@@ -283,6 +289,8 @@ class TestGameRecorder:
                     prior_p1=np.ones(5) / 5,
                     prior_p2=np.ones(5) / 5,
                     visit_counts=np.zeros((5, 5), dtype=np.int32),
+                    action_p1=0,
+                    action_p2=0,
                 )
 
             assert recorder.saved_path is not None
@@ -302,6 +310,8 @@ class TestGameRecorder:
                     prior_p1=np.ones(5) / 5,
                     prior_p2=np.ones(5) / 5,
                     visit_counts=np.zeros((5, 5), dtype=np.int32),
+                    action_p1=0,
+                    action_p2=0,
                 )
                 game.player1_score = 10.0
                 game.player2_score = 5.0
@@ -324,6 +334,8 @@ class TestGameRecorder:
                     prior_p1=np.ones(5) / 5,
                     prior_p2=np.ones(5) / 5,
                     visit_counts=np.zeros((5, 5), dtype=np.int32),
+                    action_p1=0,
+                    action_p2=0,
                 )
                 game.player1_score = 5.0
                 game.player2_score = 5.0
@@ -355,6 +367,8 @@ class TestGameRecorder:
                         prior_p1=np.ones(5) / 5,
                         prior_p2=np.ones(5) / 5,
                         visit_counts=np.zeros((5, 5), dtype=np.int32),
+                        action_p1=0,
+                        action_p2=0,
                     )
                     raise ValueError("Simulated error")
             except ValueError:
@@ -379,6 +393,8 @@ class TestSavedArrays:
                     prior_p1=np.ones(5) / 5,
                     prior_p2=np.ones(5) / 5,
                     visit_counts=np.zeros((5, 5), dtype=np.int32),
+                    action_p1=0,
+                    action_p2=0,
                 )
 
             assert recorder.saved_path is not None
@@ -406,6 +422,8 @@ class TestSavedArrays:
                 "prior_p2",
                 "policy_p1",
                 "policy_p2",
+                "action_p1",
+                "action_p2",
             }
 
             assert set(data.keys()) == expected_keys
@@ -427,6 +445,8 @@ class TestSavedArrays:
                         prior_p1=np.ones(5) / 5,
                         prior_p2=np.ones(5) / 5,
                         visit_counts=np.zeros((5, 5), dtype=np.int32),
+                        action_p1=0,
+                        action_p2=0,
                     )
 
             assert recorder.saved_path is not None
@@ -466,6 +486,8 @@ class TestSavedArrays:
                     prior_p1=np.ones(5) / 5,
                     prior_p2=np.ones(5) / 5,
                     visit_counts=np.zeros((5, 5), dtype=np.int32),
+                    action_p1=0,
+                    action_p2=0,
                 )
 
             assert recorder.saved_path is not None
@@ -521,6 +543,8 @@ class TestRoundtrip:
                     prior_p1=np.ones(5) / 5,
                     prior_p2=np.ones(5) / 5,
                     visit_counts=np.zeros((5, 5), dtype=np.int32),
+                    action_p1=0,
+                    action_p2=0,
                 )
 
             assert recorder.saved_path is not None
@@ -553,6 +577,8 @@ class TestRoundtrip:
                     prior_p1=np.ones(5) / 5,
                     prior_p2=np.ones(5) / 5,
                     visit_counts=np.zeros((5, 5), dtype=np.int32),
+                    action_p1=0,
+                    action_p2=0,
                 )
 
             assert recorder.saved_path is not None
@@ -585,6 +611,8 @@ class TestRoundtrip:
                     prior_p1=np.ones(5) / 5,
                     prior_p2=np.ones(5) / 5,
                     visit_counts=np.zeros((5, 5), dtype=np.int32),
+                    action_p1=0,
+                    action_p2=0,
                 )
 
             assert recorder.saved_path is not None
@@ -645,6 +673,8 @@ class TestRoundtrip:
                     prior_p1=prior_p1,
                     prior_p2=prior_p2,
                     visit_counts=visits,
+                    action_p1=0,
+                    action_p2=0,
                 )
 
             assert recorder.saved_path is not None
@@ -676,6 +706,8 @@ class TestRoundtrip:
                     prior_p1=np.ones(5) / 5,
                     prior_p2=np.ones(5) / 5,
                     visit_counts=np.ones((5, 5), dtype=np.int32),
+                    action_p1=0,
+                    action_p2=0,
                 )
 
                 # Position 1
@@ -688,6 +720,8 @@ class TestRoundtrip:
                     prior_p1=np.ones(5) / 5,
                     prior_p2=np.ones(5) / 5,
                     visit_counts=np.ones((5, 5), dtype=np.int32) * 2,
+                    action_p1=0,
+                    action_p2=0,
                 )
 
                 # Position 2
@@ -699,6 +733,8 @@ class TestRoundtrip:
                     prior_p1=np.ones(5) / 5,
                     prior_p2=np.ones(5) / 5,
                     visit_counts=np.ones((5, 5), dtype=np.int32) * 3,
+                    action_p1=0,
+                    action_p2=0,
                 )
 
             assert recorder.saved_path is not None
@@ -736,6 +772,8 @@ class TestRoundtrip:
                     prior_p1=np.ones(5) / 5,
                     prior_p2=np.ones(5) / 5,
                     visit_counts=np.zeros((5, 5), dtype=np.int32),
+                    action_p1=0,
+                    action_p2=0,
                 )
 
             assert recorder.saved_path is not None

--- a/tests/nn/builders/test_flat.py
+++ b/tests/nn/builders/test_flat.py
@@ -291,6 +291,8 @@ def _create_game_npz(
     prior_p2 = np.ones((n, 5), dtype=np.float32) / 5
     policy_p1 = np.ones((n, 5), dtype=np.float32) / 5
     policy_p2 = np.ones((n, 5), dtype=np.float32) / 5
+    action_p1 = np.zeros(n, dtype=np.int8)
+    action_p2 = np.zeros(n, dtype=np.int8)
 
     np.savez_compressed(
         path,
@@ -315,6 +317,8 @@ def _create_game_npz(
         prior_p2=prior_p2,
         policy_p1=policy_p1,
         policy_p2=policy_p2,
+        action_p1=action_p1,
+        action_p2=action_p2,
     )
 
 

--- a/tests/nn/test_extraction.py
+++ b/tests/nn/test_extraction.py
@@ -85,6 +85,8 @@ def _make_position_data(
     p2_mud: int = 2,
     cheese_positions: list[tuple[int, int]] | None = None,
     turn: int = 10,
+    action_p1: int = 0,
+    action_p2: int = 0,
 ) -> PositionData:
     """Create PositionData with defaults for testing."""
     if cheese_positions is None:
@@ -105,6 +107,8 @@ def _make_position_data(
         prior_p2=np.ones(5, dtype=np.float32) / 5,
         policy_p1=np.ones(5, dtype=np.float32) / 5,
         policy_p2=np.ones(5, dtype=np.float32) / 5,
+        action_p1=action_p1,
+        action_p2=action_p2,
     )
 
 
@@ -409,6 +413,8 @@ class TestTrainInferenceConsistency:
             prior_p2=np.ones(5, dtype=np.float32) / 5,
             policy_p1=np.ones(5, dtype=np.float32) / 5,
             policy_p2=np.ones(5, dtype=np.float32) / 5,
+            action_p1=0,
+            action_p2=0,
         )
 
         # Extract via both paths
@@ -478,6 +484,8 @@ class TestTrainInferenceConsistency:
             prior_p2=np.ones(5, dtype=np.float32) / 5,
             policy_p1=np.ones(5, dtype=np.float32) / 5,
             policy_p2=np.ones(5, dtype=np.float32) / 5,
+            action_p1=0,
+            action_p2=0,
         )
 
         obs_training = from_game_arrays(game_data, position_data)
@@ -535,6 +543,8 @@ class TestTrainInferenceConsistency:
             prior_p2=np.ones(5, dtype=np.float32) / 5,
             policy_p1=np.ones(5, dtype=np.float32) / 5,
             policy_p2=np.ones(5, dtype=np.float32) / 5,
+            action_p1=0,
+            action_p2=0,
         )
 
         obs_training = from_game_arrays(game_data, position_data)
@@ -596,6 +606,8 @@ class TestTrainInferenceConsistency:
             prior_p2=np.ones(5, dtype=np.float32) / 5,
             policy_p1=np.ones(5, dtype=np.float32) / 5,
             policy_p2=np.ones(5, dtype=np.float32) / 5,
+            action_p1=0,
+            action_p2=0,
         )
 
         obs_training = from_game_arrays(game_data, position_data)

--- a/tests/nn/test_streaming.py
+++ b/tests/nn/test_streaming.py
@@ -61,6 +61,8 @@ def _create_game_npz(
     prior_p2 = np.ones((n, 5), dtype=np.float32) / 5
     policy_p1 = np.ones((n, 5), dtype=np.float32) / 5
     policy_p2 = np.ones((n, 5), dtype=np.float32) / 5
+    action_p1 = np.zeros(n, dtype=np.int8)
+    action_p2 = np.zeros(n, dtype=np.int8)
 
     np.savez_compressed(
         path,
@@ -85,6 +87,8 @@ def _create_game_npz(
         prior_p2=prior_p2,
         policy_p1=policy_p1,
         policy_p2=policy_p2,
+        action_p1=action_p1,
+        action_p2=action_p2,
     )
 
 

--- a/tests/nn/test_targets.py
+++ b/tests/nn/test_targets.py
@@ -39,6 +39,8 @@ def _make_position_data(
     p1_score: float = 0.0,
     p2_score: float = 0.0,
     turn: int = 0,
+    action_p1: int = 0,
+    action_p2: int = 0,
 ) -> PositionData:
     """Create PositionData with defaults for testing."""
     if policy_p1 is None:
@@ -61,6 +63,8 @@ def _make_position_data(
         prior_p2=np.ones(5, dtype=np.float32) / 5,
         policy_p1=policy_p1,
         policy_p2=policy_p2,
+        action_p1=action_p1,
+        action_p2=action_p2,
     )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,15 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "absl-py"
+version = "2.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/10/2a/c93173ffa1b39c1d0395b7e842bbdc62e556ca9d8d3b5572926f3e4ca752/absl_py-2.3.1.tar.gz", hash = "sha256:a97820526f7fbfd2ec1bce83f3f25e3a14840dac0d8e02a0b71cd75db3f77fc9", size = 116588, upload-time = "2025-07-03T09:31:44.05Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/aa/ba0014cc4659328dc818a28827be78e6d97312ab0cb98105a770924dc11e/absl_py-2.3.1-py3-none-any.whl", hash = "sha256:eeecf07f0c2a93ace0772c92e596ace6d3d3996c042b2128459aaae2a76de11d", size = 135811, upload-time = "2025-07-03T09:31:42.253Z" },
+]
+
+[[package]]
 name = "alembic"
 version = "1.17.2"
 source = { registry = "https://pypi.org/simple" }
@@ -48,6 +57,7 @@ dev = [
     { name = "types-pyyaml" },
 ]
 train = [
+    { name = "tensorboard" },
     { name = "torch" },
 ]
 
@@ -74,6 +84,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
+    { name = "tensorboard", marker = "extra == 'train'", specifier = ">=2.15" },
     { name = "torch", marker = "extra == 'train'", specifier = ">=2.0" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
 ]
@@ -480,6 +491,57 @@ wheels = [
 ]
 
 [[package]]
+name = "grpcio"
+version = "1.76.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b6/e0/318c1ce3ae5a17894d5791e87aea147587c9e702f24122cc7a5c8bbaeeb1/grpcio-1.76.0.tar.gz", hash = "sha256:7be78388d6da1a25c0d5ec506523db58b18be22d9c37d8d3a32c08be4987bd73", size = 12785182, upload-time = "2025-10-21T16:23:12.106Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/00/8163a1beeb6971f66b4bbe6ac9457b97948beba8dd2fc8e1281dce7f79ec/grpcio-1.76.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:2e1743fbd7f5fa713a1b0a8ac8ebabf0ec980b5d8809ec358d488e273b9cf02a", size = 5843567, upload-time = "2025-10-21T16:20:52.829Z" },
+    { url = "https://files.pythonhosted.org/packages/10/c1/934202f5cf335e6d852530ce14ddb0fef21be612ba9ecbbcbd4d748ca32d/grpcio-1.76.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:a8c2cf1209497cf659a667d7dea88985e834c24b7c3b605e6254cbb5076d985c", size = 11848017, upload-time = "2025-10-21T16:20:56.705Z" },
+    { url = "https://files.pythonhosted.org/packages/11/0b/8dec16b1863d74af6eb3543928600ec2195af49ca58b16334972f6775663/grpcio-1.76.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:08caea849a9d3c71a542827d6df9d5a69067b0a1efbea8a855633ff5d9571465", size = 6412027, upload-time = "2025-10-21T16:20:59.3Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/64/7b9e6e7ab910bea9d46f2c090380bab274a0b91fb0a2fe9b0cd399fffa12/grpcio-1.76.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:f0e34c2079d47ae9f6188211db9e777c619a21d4faba6977774e8fa43b085e48", size = 7075913, upload-time = "2025-10-21T16:21:01.645Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/093c46e9546073cefa789bd76d44c5cb2abc824ca62af0c18be590ff13ba/grpcio-1.76.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8843114c0cfce61b40ad48df65abcfc00d4dba82eae8718fab5352390848c5da", size = 6615417, upload-time = "2025-10-21T16:21:03.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/b6/5709a3a68500a9c03da6fb71740dcdd5ef245e39266461a03f31a57036d8/grpcio-1.76.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8eddfb4d203a237da6f3cc8a540dad0517d274b5a1e9e636fd8d2c79b5c1d397", size = 7199683, upload-time = "2025-10-21T16:21:06.195Z" },
+    { url = "https://files.pythonhosted.org/packages/91/d3/4b1f2bf16ed52ce0b508161df3a2d186e4935379a159a834cb4a7d687429/grpcio-1.76.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:32483fe2aab2c3794101c2a159070584e5db11d0aa091b2c0ea9c4fc43d0d749", size = 8163109, upload-time = "2025-10-21T16:21:08.498Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/61/d9043f95f5f4cf085ac5dd6137b469d41befb04bd80280952ffa2a4c3f12/grpcio-1.76.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:dcfe41187da8992c5f40aa8c5ec086fa3672834d2be57a32384c08d5a05b4c00", size = 7626676, upload-time = "2025-10-21T16:21:10.693Z" },
+    { url = "https://files.pythonhosted.org/packages/36/95/fd9a5152ca02d8881e4dd419cdd790e11805979f499a2e5b96488b85cf27/grpcio-1.76.0-cp311-cp311-win32.whl", hash = "sha256:2107b0c024d1b35f4083f11245c0e23846ae64d02f40b2b226684840260ed054", size = 3997688, upload-time = "2025-10-21T16:21:12.746Z" },
+    { url = "https://files.pythonhosted.org/packages/60/9c/5c359c8d4c9176cfa3c61ecd4efe5affe1f38d9bae81e81ac7186b4c9cc8/grpcio-1.76.0-cp311-cp311-win_amd64.whl", hash = "sha256:522175aba7af9113c48ec10cc471b9b9bd4f6ceb36aeb4544a8e2c80ed9d252d", size = 4709315, upload-time = "2025-10-21T16:21:15.26Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/05/8e29121994b8d959ffa0afd28996d452f291b48cfc0875619de0bde2c50c/grpcio-1.76.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:81fd9652b37b36f16138611c7e884eb82e0cec137c40d3ef7c3f9b3ed00f6ed8", size = 5799718, upload-time = "2025-10-21T16:21:17.939Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/75/11d0e66b3cdf998c996489581bdad8900db79ebd83513e45c19548f1cba4/grpcio-1.76.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:04bbe1bfe3a68bbfd4e52402ab7d4eb59d72d02647ae2042204326cf4bbad280", size = 11825627, upload-time = "2025-10-21T16:21:20.466Z" },
+    { url = "https://files.pythonhosted.org/packages/28/50/2f0aa0498bc188048f5d9504dcc5c2c24f2eb1a9337cd0fa09a61a2e75f0/grpcio-1.76.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d388087771c837cdb6515539f43b9d4bf0b0f23593a24054ac16f7a960be16f4", size = 6359167, upload-time = "2025-10-21T16:21:23.122Z" },
+    { url = "https://files.pythonhosted.org/packages/66/e5/bbf0bb97d29ede1d59d6588af40018cfc345b17ce979b7b45424628dc8bb/grpcio-1.76.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:9f8f757bebaaea112c00dba718fc0d3260052ce714e25804a03f93f5d1c6cc11", size = 7044267, upload-time = "2025-10-21T16:21:25.995Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/86/f6ec2164f743d9609691115ae8ece098c76b894ebe4f7c94a655c6b03e98/grpcio-1.76.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:980a846182ce88c4f2f7e2c22c56aefd515daeb36149d1c897f83cf57999e0b6", size = 6573963, upload-time = "2025-10-21T16:21:28.631Z" },
+    { url = "https://files.pythonhosted.org/packages/60/bc/8d9d0d8505feccfdf38a766d262c71e73639c165b311c9457208b56d92ae/grpcio-1.76.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f92f88e6c033db65a5ae3d97905c8fea9c725b63e28d5a75cb73b49bda5024d8", size = 7164484, upload-time = "2025-10-21T16:21:30.837Z" },
+    { url = "https://files.pythonhosted.org/packages/67/e6/5d6c2fc10b95edf6df9b8f19cf10a34263b7fd48493936fffd5085521292/grpcio-1.76.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:4baf3cbe2f0be3289eb68ac8ae771156971848bb8aaff60bad42005539431980", size = 8127777, upload-time = "2025-10-21T16:21:33.577Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/c8/dce8ff21c86abe025efe304d9e31fdb0deaaa3b502b6a78141080f206da0/grpcio-1.76.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:615ba64c208aaceb5ec83bfdce7728b80bfeb8be97562944836a7a0a9647d882", size = 7594014, upload-time = "2025-10-21T16:21:41.882Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/42/ad28191ebf983a5d0ecef90bab66baa5a6b18f2bfdef9d0a63b1973d9f75/grpcio-1.76.0-cp312-cp312-win32.whl", hash = "sha256:45d59a649a82df5718fd9527ce775fd66d1af35e6d31abdcdc906a49c6822958", size = 3984750, upload-time = "2025-10-21T16:21:44.006Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/00/7bd478cbb851c04a48baccaa49b75abaa8e4122f7d86da797500cccdd771/grpcio-1.76.0-cp312-cp312-win_amd64.whl", hash = "sha256:c088e7a90b6017307f423efbb9d1ba97a22aa2170876223f9709e9d1de0b5347", size = 4704003, upload-time = "2025-10-21T16:21:46.244Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/ed/71467ab770effc9e8cef5f2e7388beb2be26ed642d567697bb103a790c72/grpcio-1.76.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:26ef06c73eb53267c2b319f43e6634c7556ea37672029241a056629af27c10e2", size = 5807716, upload-time = "2025-10-21T16:21:48.475Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/85/c6ed56f9817fab03fa8a111ca91469941fb514e3e3ce6d793cb8f1e1347b/grpcio-1.76.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:45e0111e73f43f735d70786557dc38141185072d7ff8dc1829d6a77ac1471468", size = 11821522, upload-time = "2025-10-21T16:21:51.142Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/31/2b8a235ab40c39cbc141ef647f8a6eb7b0028f023015a4842933bc0d6831/grpcio-1.76.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:83d57312a58dcfe2a3a0f9d1389b299438909a02db60e2f2ea2ae2d8034909d3", size = 6362558, upload-time = "2025-10-21T16:21:54.213Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/64/9784eab483358e08847498ee56faf8ff6ea8e0a4592568d9f68edc97e9e9/grpcio-1.76.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:3e2a27c89eb9ac3d81ec8835e12414d73536c6e620355d65102503064a4ed6eb", size = 7049990, upload-time = "2025-10-21T16:21:56.476Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/94/8c12319a6369434e7a184b987e8e9f3b49a114c489b8315f029e24de4837/grpcio-1.76.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:61f69297cba3950a524f61c7c8ee12e55c486cb5f7db47ff9dcee33da6f0d3ae", size = 6575387, upload-time = "2025-10-21T16:21:59.051Z" },
+    { url = "https://files.pythonhosted.org/packages/15/0f/f12c32b03f731f4a6242f771f63039df182c8b8e2cf8075b245b409259d4/grpcio-1.76.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6a15c17af8839b6801d554263c546c69c4d7718ad4321e3166175b37eaacca77", size = 7166668, upload-time = "2025-10-21T16:22:02.049Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/2d/3ec9ce0c2b1d92dd59d1c3264aaec9f0f7c817d6e8ac683b97198a36ed5a/grpcio-1.76.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:25a18e9810fbc7e7f03ec2516addc116a957f8cbb8cbc95ccc80faa072743d03", size = 8124928, upload-time = "2025-10-21T16:22:04.984Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/74/fd3317be5672f4856bcdd1a9e7b5e17554692d3db9a3b273879dc02d657d/grpcio-1.76.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:931091142fd8cc14edccc0845a79248bc155425eee9a98b2db2ea4f00a235a42", size = 7589983, upload-time = "2025-10-21T16:22:07.881Z" },
+    { url = "https://files.pythonhosted.org/packages/45/bb/ca038cf420f405971f19821c8c15bcbc875505f6ffadafe9ffd77871dc4c/grpcio-1.76.0-cp313-cp313-win32.whl", hash = "sha256:5e8571632780e08526f118f74170ad8d50fb0a48c23a746bef2a6ebade3abd6f", size = 3984727, upload-time = "2025-10-21T16:22:10.032Z" },
+    { url = "https://files.pythonhosted.org/packages/41/80/84087dc56437ced7cdd4b13d7875e7439a52a261e3ab4e06488ba6173b0a/grpcio-1.76.0-cp313-cp313-win_amd64.whl", hash = "sha256:f9f7bd5faab55f47231ad8dba7787866b69f5e93bc306e3915606779bbfb4ba8", size = 4702799, upload-time = "2025-10-21T16:22:12.709Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/46/39adac80de49d678e6e073b70204091e76631e03e94928b9ea4ecf0f6e0e/grpcio-1.76.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:ff8a59ea85a1f2191a0ffcc61298c571bc566332f82e5f5be1b83c9d8e668a62", size = 5808417, upload-time = "2025-10-21T16:22:15.02Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/f5/a4531f7fb8b4e2a60b94e39d5d924469b7a6988176b3422487be61fe2998/grpcio-1.76.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:06c3d6b076e7b593905d04fdba6a0525711b3466f43b3400266f04ff735de0cd", size = 11828219, upload-time = "2025-10-21T16:22:17.954Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/1c/de55d868ed7a8bd6acc6b1d6ddc4aa36d07a9f31d33c912c804adb1b971b/grpcio-1.76.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fd5ef5932f6475c436c4a55e4336ebbe47bd3272be04964a03d316bbf4afbcbc", size = 6367826, upload-time = "2025-10-21T16:22:20.721Z" },
+    { url = "https://files.pythonhosted.org/packages/59/64/99e44c02b5adb0ad13ab3adc89cb33cb54bfa90c74770f2607eea629b86f/grpcio-1.76.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:b331680e46239e090f5b3cead313cc772f6caa7d0fc8de349337563125361a4a", size = 7049550, upload-time = "2025-10-21T16:22:23.637Z" },
+    { url = "https://files.pythonhosted.org/packages/43/28/40a5be3f9a86949b83e7d6a2ad6011d993cbe9b6bd27bea881f61c7788b6/grpcio-1.76.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2229ae655ec4e8999599469559e97630185fdd53ae1e8997d147b7c9b2b72cba", size = 6575564, upload-time = "2025-10-21T16:22:26.016Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/a9/1be18e6055b64467440208a8559afac243c66a8b904213af6f392dc2212f/grpcio-1.76.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:490fa6d203992c47c7b9e4a9d39003a0c2bcc1c9aa3c058730884bbbb0ee9f09", size = 7176236, upload-time = "2025-10-21T16:22:28.362Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/55/dba05d3fcc151ce6e81327541d2cc8394f442f6b350fead67401661bf041/grpcio-1.76.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:479496325ce554792dba6548fae3df31a72cef7bad71ca2e12b0e58f9b336bfc", size = 8125795, upload-time = "2025-10-21T16:22:31.075Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/45/122df922d05655f63930cf42c9e3f72ba20aadb26c100ee105cad4ce4257/grpcio-1.76.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:1c9b93f79f48b03ada57ea24725d83a30284a012ec27eab2cf7e50a550cbbbcc", size = 7592214, upload-time = "2025-10-21T16:22:33.831Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/6e/0b899b7f6b66e5af39e377055fb4a6675c9ee28431df5708139df2e93233/grpcio-1.76.0-cp314-cp314-win32.whl", hash = "sha256:747fa73efa9b8b1488a95d0ba1039c8e2dca0f741612d80415b1e1c560febf4e", size = 4062961, upload-time = "2025-10-21T16:22:36.468Z" },
+    { url = "https://files.pythonhosted.org/packages/19/41/0b430b01a2eb38ee887f88c1f07644a1df8e289353b78e82b37ef988fb64/grpcio-1.76.0-cp314-cp314-win_amd64.whl", hash = "sha256:922fa70ba549fce362d2e2871ab542082d66e2aaf0c19480ea453905b01f384e", size = 4834462, upload-time = "2025-10-21T16:22:39.772Z" },
+]
+
+[[package]]
 name = "gymnasium"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -649,6 +711,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9e/38/bd5b78a920a64d708fe6bc8e0a2c075e1389d53bef8413725c63ba041535/mako-1.3.10.tar.gz", hash = "sha256:99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28", size = 392474, upload-time = "2025-04-10T12:44:31.16Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/87/fb/99f81ac72ae23375f22b7afdb7642aba97c00a713c217124420147681a2f/mako-1.3.10-py3-none-any.whl", hash = "sha256:baef24a52fc4fc514a0887ac600f9f1cff3d82c61d4d700a1fa84d597b88db59", size = 78509, upload-time = "2025-04-10T12:50:53.297Z" },
+]
+
+[[package]]
+name = "markdown"
+version = "3.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/ab/7dd27d9d863b3376fcf23a5a13cb5d024aed1db46f963f1b5735ae43b3be/markdown-3.10.tar.gz", hash = "sha256:37062d4f2aa4b2b6b32aefb80faa300f82cc790cb949a35b8caede34f2b68c0e", size = 364931, upload-time = "2025-11-03T19:51:15.007Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/70/81/54e3ce63502cd085a0c556652a4e1b919c45a446bd1e5300e10c44c8c521/markdown-3.10-py3-none-any.whl", hash = "sha256:b5b99d6951e2e4948d939255596523444c0e677c669700b1d17aa4a8a464cb7c", size = 107678, upload-time = "2025-11-03T19:51:13.887Z" },
 ]
 
 [[package]]
@@ -1434,6 +1505,21 @@ wheels = [
 ]
 
 [[package]]
+name = "protobuf"
+version = "6.33.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/44/e49ecff446afeec9d1a66d6bbf9adc21e3c7cea7803a920ca3773379d4f6/protobuf-6.33.2.tar.gz", hash = "sha256:56dc370c91fbb8ac85bc13582c9e373569668a290aa2e66a590c2a0d35ddb9e4", size = 444296, upload-time = "2025-12-06T00:17:53.311Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/91/1e3a34881a88697a7354ffd177e8746e97a722e5e8db101544b47e84afb1/protobuf-6.33.2-cp310-abi3-win32.whl", hash = "sha256:87eb388bd2d0f78febd8f4c8779c79247b26a5befad525008e49a6955787ff3d", size = 425603, upload-time = "2025-12-06T00:17:41.114Z" },
+    { url = "https://files.pythonhosted.org/packages/64/20/4d50191997e917ae13ad0a235c8b42d8c1ab9c3e6fd455ca16d416944355/protobuf-6.33.2-cp310-abi3-win_amd64.whl", hash = "sha256:fc2a0e8b05b180e5fc0dd1559fe8ebdae21a27e81ac77728fb6c42b12c7419b4", size = 436930, upload-time = "2025-12-06T00:17:43.278Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/ca/7e485da88ba45c920fb3f50ae78de29ab925d9e54ef0de678306abfbb497/protobuf-6.33.2-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:d9b19771ca75935b3a4422957bc518b0cecb978b31d1dd12037b088f6bcc0e43", size = 427621, upload-time = "2025-12-06T00:17:44.445Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/4f/f743761e41d3b2b2566748eb76bbff2b43e14d5fcab694f494a16458b05f/protobuf-6.33.2-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:b5d3b5625192214066d99b2b605f5783483575656784de223f00a8d00754fc0e", size = 324460, upload-time = "2025-12-06T00:17:45.678Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/fa/26468d00a92824020f6f2090d827078c09c9c587e34cbfd2d0c7911221f8/protobuf-6.33.2-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:8cd7640aee0b7828b6d03ae518b5b4806fdfc1afe8de82f79c3454f8aef29872", size = 339168, upload-time = "2025-12-06T00:17:46.813Z" },
+    { url = "https://files.pythonhosted.org/packages/56/13/333b8f421738f149d4fe5e49553bc2a2ab75235486259f689b4b91f96cec/protobuf-6.33.2-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:1f8017c48c07ec5859106533b682260ba3d7c5567b1ca1f24297ce03384d1b4f", size = 323270, upload-time = "2025-12-06T00:17:48.253Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/15/4f02896cc3df04fc465010a4c6a0cd89810f54617a32a70ef531ed75d61c/protobuf-6.33.2-py3-none-any.whl", hash = "sha256:7636aad9bb01768870266de5dc009de2d1b936771b38a793f73cbbf279c91c5c", size = 170501, upload-time = "2025-12-06T00:17:52.211Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.12.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1909,6 +1995,36 @@ wheels = [
 ]
 
 [[package]]
+name = "tensorboard"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "absl-py" },
+    { name = "grpcio" },
+    { name = "markdown" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "protobuf" },
+    { name = "setuptools" },
+    { name = "tensorboard-data-server" },
+    { name = "werkzeug" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/d9/a5db55f88f258ac669a92858b70a714bbbd5acd993820b41ec4a96a4d77f/tensorboard-2.20.0-py3-none-any.whl", hash = "sha256:9dc9f978cb84c0723acf9a345d96c184f0293d18f166bb8d59ee098e6cfaaba6", size = 5525680, upload-time = "2025-07-17T19:20:49.638Z" },
+]
+
+[[package]]
+name = "tensorboard-data-server"
+version = "0.7.2"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/13/e503968fefabd4c6b2650af21e110aa8466fe21432cd7c43a84577a89438/tensorboard_data_server-0.7.2-py3-none-any.whl", hash = "sha256:7e0610d205889588983836ec05dc098e80f97b7e7bbff7e994ebb78f578d0ddb", size = 2356, upload-time = "2023-10-23T21:23:32.16Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/85/dabeaf902892922777492e1d253bb7e1264cadce3cea932f7ff599e53fea/tensorboard_data_server-0.7.2-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:9fe5d24221b29625dbc7328b0436ca7fc1c23de4acf4d272f1180856e32f9f60", size = 4823598, upload-time = "2023-10-23T21:23:33.714Z" },
+    { url = "https://files.pythonhosted.org/packages/73/c6/825dab04195756cf8ff2e12698f22513b3db2f64925bdd41671bfb33aaa5/tensorboard_data_server-0.7.2-py3-none-manylinux_2_31_x86_64.whl", hash = "sha256:ef687163c24185ae9754ed5650eb5bc4d84ff257aabdc33f0cc6f74d8ba54530", size = 6590363, upload-time = "2023-10-23T21:23:35.583Z" },
+]
+
+[[package]]
 name = "tomli"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2098,6 +2214,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/20/28/e6f1a6f655d620846bd9df527390ecc26b3805a0c5989048c210e22c5ca9/virtualenv-20.35.4.tar.gz", hash = "sha256:643d3914d73d3eeb0c552cbb12d7e82adf0e504dbf86a3182f8771a153a1971c", size = 6028799, upload-time = "2025-10-29T06:57:40.511Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/0c/c05523fa3181fdf0c9c52a6ba91a23fbf3246cc095f26f6516f9c60e6771/virtualenv-20.35.4-py3-none-any.whl", hash = "sha256:c21c9cede36c9753eeade68ba7d523529f228a403463376cf821eaae2b650f1b", size = 6005095, upload-time = "2025-10-29T06:57:37.598Z" },
+]
+
+[[package]]
+name = "werkzeug"
+version = "3.1.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/45/ea/b0f8eeb287f8df9066e56e831c7824ac6bab645dd6c7a8f4b2d767944f9b/werkzeug-3.1.4.tar.gz", hash = "sha256:cd3cd98b1b92dc3b7b3995038826c68097dcb16f9baa63abe35f20eafeb9fe5e", size = 864687, upload-time = "2025-11-29T02:15:22.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/f9/9e082990c2585c744734f85bec79b5dae5df9c974ffee58fe421652c8e91/werkzeug-3.1.4-py3-none-any.whl", hash = "sha256:2ad50fb9ed09cc3af22c54698351027ace879a0b60a3b5edf5730b2f7d876905", size = 224960, upload-time = "2025-11-29T02:15:21.13Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add `action_p1`, `action_p2` to PositionData and recording
- Thread `payout_matrix` through sharding to training shards
- Add `prepare_training_set_with_split()` for game-level train/val splits
- Extract `_load_positions_from_files()` to eliminate duplication

## Test plan
- [x] All 268 tests pass
- [x] mypy clean
- [x] ruff clean
- [x] New tests for `prepare_training_set_with_split` (6 tests)
- [x] Updated shard tests verify new fields (keys, shapes, dtypes)