### PR TITLE
docs: Update README and CLAUDE.md to reflect current state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,224 +1,284 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Guidance for coding agents working in this repository.
 
 ## Project Overview
 
-**alpharat** is an experimental AlphaZero adaptation implementing game-theoretic Monte Carlo Tree Search (MCTS) for simultaneous two-player games, specifically targeting the PyRat game. The project uses Python 3.11+ and employs strict type checking with mypy.
+**alpharat** is a game-theoretic MCTS implementation for simultaneous two-player games, targeting PyRat (a maze game where both players move at the same time). Standard MCTS doesn't work for simultaneous moves — this project uses payout matrices and Nash equilibrium computation instead of single Q-values.
 
-### PyRat Game Context
-
-PyRat is a two-player simultaneous-move maze game where players (Rat and Python) compete to collect cheese. Key game mechanics:
-- **Simultaneous moves**: Both players submit actions at the same time
-- **Mud delays**: Movement through mud cells takes N turns, during which the player is stuck
-- **Scoring**: Collect cheese for points (1 point normal, 0.5 each if collected simultaneously)
-- **Zero-sum formulation**: The implementation tracks score differential (score_p1 - score_p2)
-- **Actions**: UP, DOWN, LEFT, RIGHT, STAY (encoded as integers 0-4)
-
-The simultaneous-move nature is why standard MCTS approaches don't work directly - this project implements a game-theoretic MCTS that uses Nash equilibrium computation.
+Python 3.11+, strict mypy, `uv` for package management.
 
 ## Development Commands
 
-**Note**: This project uses `uv` for package management. Use `uv run` to execute commands in the virtual environment.
-
-### Environment Setup
 ```bash
-# Install dependencies
-uv sync
+# Setup
+uv sync                              # Install dependencies
+uv sync --extra train                # Include PyTorch for training
+uv run pre-commit install            # Install hooks
 
-# Install pre-commit hooks
-uv run pre-commit install
+# Testing
+uv run pytest                        # All tests with coverage
+uv run pytest tests/mcts/test_node.py  # Specific file
+uv run pytest --no-cov               # Skip coverage
+
+# Code quality
+uv run ruff format .                 # Format
+uv run ruff check --fix .            # Lint
+uv run mypy alpharat                 # Type check
+uv run pre-commit run --all-files    # All hooks
 ```
 
-### Testing
-```bash
-# Run all tests with coverage
-uv run pytest
+## Project Structure
 
-# Run specific test file
-uv run pytest tests/mcts/test_node.py
+```
+alpharat/
+├── mcts/           # Core MCTS: nodes, tree, search, Nash equilibrium
+├── data/           # Data pipeline: sampling, recording, sharding
+├── nn/             # Neural network: observation builders, targets, models
+├── ai/             # Agents: MCTS, random, greedy
+└── eval/           # Evaluation: game execution, tournaments
 
-# Run specific test
-uv run pytest tests/mcts/test_node.py::test_backup_no_mud
-
-# Run without coverage
-uv run pytest --no-cov
+scripts/            # Entry points: sample.py, train_mcts.py
+configs/            # YAML configs for sampling, evaluation, benchmarks
+tests/              # Mirrors alpharat/ structure
 ```
 
-### Code Quality
-```bash
-# Format code with ruff
-uv run ruff format .
+### alpharat/mcts/
 
-# Lint and auto-fix issues
-uv run ruff check --fix .
+| File | Purpose |
+|------|---------|
+| `node.py` | `MCTSNode` — payout matrices `[5,5]` instead of Q-values, action equivalence |
+| `tree.py` | `MCTSTree` — efficient navigation via `make_move/unmake_move` |
+| `search.py` | `MCTSSearch` — prior-based sampling, returns Nash equilibrium at root |
+| `decoupled_puct.py` | Alternative selection: each player picks via PUCT formula independently |
+| `equivalence.py` | Action equivalence utilities (walls/edges/mud → same outcome) |
+| `nash.py` | Nash equilibrium computation via nashpy |
 
-# Type checking
-uv run mypy alpharat
+### alpharat/data/
 
-# Run all pre-commit hooks manually
-uv run pre-commit run --all-files
+| File | Purpose |
+|------|---------|
+| `types.py` | `PositionData`, `GameData` — data structures for recorded games |
+| `recorder.py` | `GameRecorder` — saves games as .npz during self-play |
+| `sampling.py` | `run_sampling()` — multi-worker self-play with MCTS agents |
+| `batch.py` | Batch organization and metadata |
+| `sharding.py` | `prepare_training_set()` — loads batches, shuffles globally, writes shards |
+| `loader.py` | `load_game_data()` — reconstruct GameData from .npz |
+
+### alpharat/nn/
+
+| File | Purpose |
+|------|---------|
+| `types.py` | `ObservationInput`, `TargetBundle` — source-agnostic data types |
+| `extraction.py` | Build `ObservationInput` from game arrays or live PyRat |
+| `targets.py` | `build_targets()` — Nash policies + value targets |
+| `streaming.py` | `StreamingDataset` — memory-efficient PyTorch dataset |
+| `builders/flat.py` | `FlatObservationBuilder` — 1D encoding for MLPs |
+| `models/mlp.py` | `PyRatMLP` — shared trunk + policy/payout heads |
+
+### alpharat/ai/
+
+| File | Purpose |
+|------|---------|
+| `base.py` | `Agent` ABC — `get_move(game, player) -> int` |
+| `mcts_agent.py` | `MCTSAgent` — uses MCTS search, samples from Nash |
+| `random_agent.py` | `RandomAgent` — baseline |
+| `greedy_agent.py` | `GreedyAgent` — moves toward closest cheese |
+
+### alpharat/eval/
+
+| File | Purpose |
+|------|---------|
+| `game.py` | `play_game()` — execute single game between agents |
+| `runner.py` | `evaluate()` — run N games, compute stats |
+| `tournament.py` | `run_tournament()` — round-robin with thread pool |
+
+---
+
+## Action Equivalence — The Subtle Part
+
+This is the most non-trivial aspect of the codebase. Multiple actions can lead to the same outcome (hitting walls, being stuck in mud), and this affects everything from MCTS statistics to neural network training.
+
+### The Problem
+
+In PyRat, if a player tries to move UP but there's a wall, they stay in place. So UP and STAY produce identical game states. If we treat them as different actions, MCTS explores redundant branches and Nash equilibrium computation becomes degenerate (multiple equivalent equilibria).
+
+### How It's Handled
+
+**1. Detection (`tree.py:_compute_effective_actions`)**
+
+At each position, we query `game.get_valid_moves(position)` to see which directions are actually valid. Each of the 5 actions maps to an "effective action":
+- Valid moves → map to themselves
+- Blocked moves (walls/edges) → map to STAY (action 4)
+- Mud → forces all actions to STAY for that player
+
+```python
+# Example: player against north wall
+p1_effective = [4, 1, 2, 3, 4]  # UP(0) blocked → STAY(4)
 ```
 
-## Architecture
+**2. Child Sharing (`tree.py:make_move_from`)**
 
-### Three-Script Philosophy
+When expanding, we look up children by *effective* action pair, not raw actions. Multiple raw action pairs that map to the same effective pair share a single child node:
 
-The project is designed around **three independent scripts** that communicate only through persistent data:
+```python
+# Both (UP, LEFT) and (STAY, LEFT) lead to same child if UP is blocked
+effective_pair = (node.p1_effective[action_p1], node.p2_effective[action_p2])
+if effective_pair in node.children:
+    child = node.children[effective_pair]  # Reuse existing child
+```
 
-1. **Sample Creation Script** (future): Runs MCTS agents to play games, saves game data to disk
-2. **Training Script** (future): Loads saved games, trains neural networks, saves model checkpoints
-3. **Evaluation Script** (future): Loads checkpoints, evaluates performance, determines best models
+**3. Statistics Consistency (`node.py:backup`)**
 
-**Why this matters:**
-- Full control over each phase (sampling, training, evaluation)
-- Can reuse existing data with new model architectures
-- No dependency on monolithic frameworks (avoiding RLlib, prebaked pipelines)
-- Each script can be distributed independently
+During backup, we update *all* equivalent action pairs together, not just the one played. If P1 played action 0 (UP) but it was blocked:
 
-### Core MCTS Implementation
+```python
+p1_equiv = [0, 4]  # Both UP and STAY
+p2_equiv = [2]     # Just DOWN
+# Updates the rectangular region covering all (p1_equiv × p2_equiv) pairs
+```
 
-The MCTS implementation is adapted for simultaneous-move games and lives in `alpharat/mcts/`:
+This maintains the invariant: **equivalent action pairs have identical payout matrix values**.
 
-#### Node Structure (`alpharat/mcts/node.py`)
+**4. Nash Computation (`equivalence.py:reduce_and_expand_nash`)**
 
-**Key difference from standard MCTS**: Uses **payout matrices** instead of single Q-values.
+For Nash equilibrium, we:
+1. **Reduce** the payout matrix to only effective actions (removes duplicate rows/cols)
+2. **Compute** Nash on the smaller matrix (unique equilibrium)
+3. **Expand** strategies back to full 5-action space (non-effective get 0 probability)
 
-- **Payout matrix**: Shape `[num_p1_actions, num_p2_actions]` - tracks expected values for each action pair
-- **Action visits**: Shape `[num_p1_actions, num_p2_actions]` - visit counts per action pair
-- **Neural network priors**: Separate policy priors for each player (`prior_policy_p1`, `prior_policy_p2`)
-- **Action equivalence**: Multiple actions can map to the same outcome (walls, edges, mud). See below.
+```python
+# If P1 has effective=[4,1,2,3,4], reduced matrix is 4×5 (only actions 1,2,3,4)
+# After Nash, expand: strategy[0] = 0.0 (blocked), strategy[1:5] from Nash
+```
 
-The `backup()` method uses incremental mean update: `Q_new = Q_old + (G - Q_old) / (n + 1)`
+### Flow Through Training
 
-#### Action Equivalence (`alpharat/mcts/equivalence.py`)
+**Recording (`recorder.py`):**
+- Saves post-MCTS Nash policies (which have 0 for blocked actions)
+- Saves the 5×5 payout matrix (with equivalence structure: blocked rows equal STAY rows)
 
-Multiple actions can lead to the same game state due to walls, edges, or mud. The implementation handles this through **effective action mappings**:
+**Targets (`targets.py`):**
+- Passes through the Nash policies as-is — no additional processing needed
+- The 0s for blocked actions are already baked in
 
-- **Effective mapping**: Each action maps to its effective representative. Blocked actions (hitting walls/edges) map to STAY (action 4). Mud forces all actions to STAY.
-- **Detection**: Uses `game.get_valid_moves(position)` at node creation to determine which directions are valid
-- **Node attributes**: `p1_effective` and `p2_effective` lists map action indices to their effective action
+**NN Training:**
+- The NN sees policy targets where blocked actions have probability 0
+- This creates an **implicit auxiliary task**: the NN learns maze topology
+- The NN doesn't know which actions are blocked — it learns this from the target structure
 
-**Why this matters:**
-1. **Statistics consistency**: Equivalent action pairs share identical payout matrix and visit count entries. The `backup()` method updates rectangular regions covering all equivalent pairs.
-2. **Child sharing**: `make_move_from()` effectiveizes action pairs before child lookup, so equivalent moves share the same child node.
-3. **Nash computation**: Uses reduced action space (effective actions only) for unique equilibrium. Blocked actions get probability 0 in the resulting strategy.
-4. **NN training signal**: Training with 0 probability for blocked actions creates an implicit auxiliary task—the NN must learn maze topology to predict valid moves.
+### What the NN Must Learn
 
-**Equivalence utilities**:
-- `reduce_matrix()`: Extract submatrix of effective actions only
-- `expand_strategy()`: Map reduced strategy back to full action space (0 for non-effective)
-- `reduce_and_expand_nash()`: Wrapper for Nash computation with equivalence handling
+The NN outputs:
+- `policy_p1[5]`, `policy_p2[5]` — should assign ~0 to blocked actions
+- `payout_matrix[5,5]` — should reflect equivalence structure
 
-#### Tree Management (`alpharat/mcts/tree.py`)
+This isn't hard-masked; it's learned behavior. The NN must infer from the observation (maze layout, positions) which actions are valid.
 
-**Key efficiency technique**: Uses PyRat's `make_move/unmake_move` pattern instead of storing full game states.
+### At Inference (Without NN)
 
-- Owns a PyRat game instance (the "simulator")
-- Nodes store only `MoveUndo` objects, not full game state
-- `_navigate_to()` efficiently moves simulator between nodes by:
-  1. Finding common ancestor
-  2. Unmaking moves back to ancestor
-  3. Remaking moves forward to target
-- `make_move_from()` handles both navigation and child creation
-- `backup()` propagates discounted values up the tree with gamma factor
+When `predict_fn` is None, MCTS uses "smart uniform" priors (`tree.py:_smart_uniform_prior`):
 
-#### Nash Equilibrium (`alpharat/mcts/nash.py`)
+```python
+# Only assign probability to unique effective actions
+# If effective=[4,1,2,3,4], only actions 1,2,3,4 get probability
+# Action 0 gets 0 (it's a duplicate of 4)
+```
 
-Uses `nashpy` library for computing Nash equilibria of zero-sum games:
+This is more efficient than naive uniform — doesn't waste exploration on redundant moves.
 
-- `compute_nash_equilibrium()`: Takes payout matrix and optional effective mappings, returns mixed strategies for both players. With effective mappings, computes on reduced matrix and expands back (blocked actions get 0).
-- `compute_nash_value()`: Computes expected value of a strategy profile
-- `select_action_from_strategy()`: Samples actions from mixed strategy with temperature control
+### At Inference (With NN)
 
-**Current approach** (from design docs): Prior-based sampling during search, Nash equilibrium computation only at root after search completes.
+The NN provides priors. MCTS expects:
+- Policy predictions should assign low probability to blocked actions (learned from training)
+- The tree maintains equivalence structure regardless of what the NN outputs
 
-### External Dependencies
+Even if the NN makes mistakes on blocked actions, the tree's child sharing and statistics updates preserve correctness.
 
-- **pyrat-engine**: The PyRat game simulator (`git+https://github.com/mintiti/pyrat-rust.git@main#subdirectory=engine`)
-  - Rust-backed Python module
-  - Imports: `from pyrat_engine.core.game import PyRat, MoveUndo` and `from pyrat_engine.core.types import Direction`
-  - `PyRat` game class with `make_move(p1: int, p2: int) -> MoveUndo` and `unmake_move(undo: MoveUndo)`
-  - `get_valid_moves(position)`: Returns list of valid movement directions from a position (used for equivalence detection)
-  - Properties: `player1_position`, `player2_position`, `player1_score`, `player2_score`, `player1_mud_turns`, `player2_mud_turns`, `turn`
-  - `MoveUndo` has flat attributes: `p1_mud`, `p2_mud`, `p1_pos`, `p2_pos`, etc.
-- **nashpy**: Nash equilibrium computation
-- **numpy**: Matrix operations for payout matrices
+---
 
-## Code Style and Type Checking
+## Other Architecture Notes
 
-### Ruff Configuration
-- Line length: 100 characters
-- Enabled rules: pycodestyle (E/W), pyflakes (F), isort (I), pep8-naming (N), pyupgrade (UP), bugbear (B), comprehensions (C4), simplify (SIM), type-checking (TCH)
+### Payout Matrices, Not Q-Values
 
-### Mypy Configuration
-- **Strict mode enabled**: All functions must have complete type annotations
-- Required: `disallow_untyped_defs`, `disallow_incomplete_defs`
-- Use `from __future__ import annotations` for forward references
-- Type `Any` from `typing` module for game state (external PyRat types)
+Standard MCTS stores one value per action. For simultaneous games, we need the expected value for each *pair* of actions — a 5×5 payout matrix per node.
 
-### Key Type Patterns
+### make_move / unmake_move
+
+Nodes don't store full game states. The tree owns one PyRat simulator and navigates by making/unmaking moves. Efficient for deep trees.
+
+### Prior Sampling vs Decoupled PUCT
+
+Two selection strategies:
+- **Prior sampling** (`search.py`): Sample actions from NN policy priors during search
+- **Decoupled PUCT** (`decoupled_puct.py`): Each player selects via PUCT formula independently
+
+Both compute Nash equilibrium at the root after search completes.
+
+### Zero-Sum Formulation
+
+All values from Player 1's perspective: `score_p1 - score_p2`. Value of +2 means P1 ahead by 2 cheese.
+
+---
+
+## Code Style
+
+### Type Annotations (Strict)
+
 ```python
 from __future__ import annotations
 from typing import Any
 import numpy as np
 
-# Use np.ndarray for arrays (mypy doesn't require shape annotations)
-def compute_nash_equilibrium(payout_matrix: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
-    ...
+# Arrays - no shape annotations needed
+def compute_nash(payout: np.ndarray) -> tuple[np.ndarray, np.ndarray]: ...
 
-# Use | for unions (Python 3.11+)
+# Unions with |
 parent: MCTSNode | None = None
 
-# Use Any for external game state
+# Any for external types
 game_state: Any
 ```
 
-## Testing Approach
+### Ruff Rules
+Line length 100. Enabled: pycodestyle, pyflakes, isort, pep8-naming, pyupgrade, bugbear, comprehensions, simplify, type-checking.
 
-Tests live in `tests/` mirroring the `alpharat/` structure. Current coverage focus:
-- Node backup mechanics with and without mud (`test_node.py`)
-- Nash equilibrium computation edge cases (`test_nash.py`)
-- Tree navigation and move making (`test_tree.py`)
+---
 
-Coverage reports generated in `htmlcov/` directory.
+## Dependencies
 
-## Design Documentation
+**Core:** numpy, nashpy, pydantic, pyyaml, pyrat-engine (Rust-backed)
 
-The `.mt/` folder contains personal design documentation:
-- **project-architecture.md**: Three-script philosophy and workflow
-- **mcts-implementation.md**: Detailed MCTS node design decisions
-- **game-specification.md**: Complete PyRat game rules
-- **design-exploration.md**: Open questions and alternative approaches
+**Training (optional):** torch, tensorboard
 
-**Important design decisions from these docs:**
-- Using NN prior policies during backup instead of recomputing Nash equilibrium (for stability)
-- Zero-sum formulation: All values from Player 1's perspective (score_p1 - score_p2)
-- Separation of concerns: Node handles statistics, Nash computation is external
-- Future: Policy targets will be Nash equilibrium of post-MCTS payout matrix
+**Visualization:** optuna, plotly, pandas, matplotlib
 
-## Current Implementation Status
+**pyrat-engine imports:**
+```python
+from pyrat_engine.core.game import PyRat, MoveUndo
+from pyrat_engine.core.types import Direction
+```
 
-Implemented:
-- ✓ MCTSNode with payout matrices and action equivalence handling
-- ✓ MCTSTree with efficient game state navigation and child sharing for equivalent actions
-- ✓ Nash equilibrium computation with optional equivalence reduction
-- ✓ Action equivalence utilities (reduce/expand for matrices and strategies)
-- ✓ Comprehensive unit tests for core components
-
-Not yet implemented:
-- ⧗ MCTS search algorithm (selection, expansion, simulation)
-- ⧗ Neural network architecture
-- ⧗ Training script
-- ⧗ Sampling script
-- ⧗ Evaluation script
-- ⧗ PUCT-style selection for simultaneous moves
+---
 
 ## Development Tips
 
-1. **When modifying MCTS logic**: Consider action equivalence—equivalent actions must have identical statistics. Mud is a special case where all actions become equivalent to STAY.
-2. **When adding new node statistics**: Ensure they're properly shaped `[num_actions_p1, num_actions_p2]`
-3. **When working with PyRat**: Remember it uses `make_move/unmake_move` - don't copy game state unnecessarily
-4. **When implementing selection**: The current plan is prior-based sampling (see `.mt/design-exploration.md` for alternatives)
-5. **All code must pass**: `uv run ruff check`, `uv run ruff format`, `uv run mypy`, and `uv run pytest` before committing (enforced by pre-commit hooks)
-6. **Never skip pre-commit hooks**: Do not use `--no-verify` when committing. If pre-commit fails due to pip/network issues, set `PIP_INDEX_URL=https://pypi.org/simple/ PIP_EXTRA_INDEX_URL=""` before the git command
+1. **Action equivalence is everywhere** — when modifying MCTS logic, ensure equivalent actions share statistics. If you're touching `backup()`, `make_move_from()`, or Nash computation, think through the equivalence implications.
+
+2. **Node statistics are [5,5]** — payout matrix and visit counts are per action pair, not per action.
+
+3. **Don't copy game state** — use `make_move/unmake_move` pattern.
+
+4. **Pre-commit is mandatory** — don't use `--no-verify`. If pip issues, set `PIP_INDEX_URL=https://pypi.org/simple/`.
+
+5. **The NN learns blocked actions implicitly** — training targets have 0 for blocked actions. The NN figures out which actions are blocked from the maze layout in the observation.
+
+---
+
+## Design Docs
+
+The `.mt/` folder contains detailed design documentation:
+- `project-architecture.md` — three-script philosophy
+- `mcts-implementation.md` — node design decisions
+- `game-specification.md` — PyRat rules
+- `design-exploration.md` — alternatives considered

--- a/README.md
+++ b/README.md
@@ -1,2 +1,44 @@
 # alpharat
-Experimental AlphaZero adaptation: game-theoretic MCTS for simultaneous two-player games
+
+Experimental AlphaZero-style MCTS for simultaneous two-player games.
+
+Standard MCTS assumes players take turns. PyRat (the target game here) has both players moving at the same time, which breaks that assumption. This project tries using payout matrices instead of single Q-values, and computing Nash equilibrium instead of just picking the best action.
+
+Still figuring out if it actually works.
+
+## Getting started
+
+```bash
+uv sync
+uv sync --extra train  # for PyTorch
+
+# Run tests
+uv run pytest
+
+# Generate training data
+uv run python scripts/sample.py configs/sample.yaml
+```
+
+## What's here
+
+- `alpharat/mcts/` — Tree search with 5×5 payout matrices per node, handles action equivalence, computes Nash at root
+- `alpharat/data/` — Self-play sampling, game recording, training set sharding
+- `alpharat/nn/` — Observation encoding, training targets, MLP model
+- `alpharat/ai/` — Agents (MCTS, random, greedy baselines)
+- `alpharat/eval/` — Running games and tournaments
+
+## The approach
+
+When both players move at once, you can't just maximize — the opponent is choosing too. So each node stores expected values for all 25 action pairs, and action selection uses Nash equilibrium.
+
+There's also a subtlety where multiple actions can be equivalent (hitting a wall = staying put). The tree shares branches for those and reduces the matrix before computing Nash.
+
+See [CLAUDE.md](CLAUDE.md) for implementation details.
+
+## Status
+
+Experimental. The MCTS core and data pipeline work. Training loop exists but hasn't been tested much. Don't know yet if this learns anything useful.
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary

- **README**: Proper project description, getting started, module overview, honest status
- **CLAUDE.md**: Document all modules (data, nn, ai, eval), remove outdated "not implemented" items, add detailed action equivalence section

## Why

The docs were stale — said things weren't implemented that are, and missed entire modules. The action equivalence section now traces the full flow from MCTS detection through training targets to NN inference.