### PR TITLE
feat: Add asymmetric maze support to sampling

### DIFF
--- a/alpharat/data/batch.py
+++ b/alpharat/data/batch.py
@@ -24,6 +24,7 @@ class GameParams(BaseModel):
     cheese_count: int
     wall_density: float | None = None  # None = use pyrat default (0.7)
     mud_density: float | None = None  # None = use pyrat default (0.1)
+    symmetric: bool = True  # False = asymmetric maze/cheese generation
 
 
 # --- Batch Metadata ---

--- a/alpharat/data/sampling.py
+++ b/alpharat/data/sampling.py
@@ -327,12 +327,13 @@ def create_game(params: GameParams, seed: int) -> PyRat:
     """
     from pyrat_engine.core.game import PyRat
 
-    kwargs: dict[str, int | float] = {
+    kwargs: dict[str, int | float | bool] = {
         "width": params.width,
         "height": params.height,
         "cheese_count": params.cheese_count,
         "max_turns": params.max_turns,
         "seed": seed,
+        "symmetric": params.symmetric,
     }
     if params.wall_density is not None:
         kwargs["wall_density"] = params.wall_density

--- a/configs/sample_5x5_asymmetric.yaml
+++ b/configs/sample_5x5_asymmetric.yaml
@@ -1,0 +1,25 @@
+# Self-play sampling for 5x5 with asymmetric maze/cheese
+# Usage: uv run python scripts/sample.py configs/sample_5x5_asymmetric.yaml
+# Purpose: Test training with diverse asymmetric positions
+
+mcts:
+  variant: decoupled_puct
+  simulations: 554
+  c_puct: 8.342921588471766
+  force_k: 0.8834383744890093
+
+game:
+  width: 5
+  height: 5
+  max_turns: 30
+  cheese_count: 5
+  wall_density: 0.0
+  mud_density: 0.0
+  symmetric: false
+
+sampling:
+  num_games: 50000
+  workers: 4
+
+output_dir: batches/5x5_asymmetric/
+checkpoint: null


### PR DESCRIPTION
## Summary
- Add `symmetric` parameter to `GameParams` (default `True`)
- Passes through to PyRat for asymmetric maze/cheese generation
- Includes example config for 5x5 asymmetric sampling

## Test plan
- [x] Existing batch/sampling tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)